### PR TITLE
Include cookies in the Request validation

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -124,7 +124,9 @@ class TestRequestFactory(unittest.TestCase):
         expected = OpenAPIRequest(
             full_url_pattern=url,
             method="get",
-            parameters=RequestParameters(query=ImmutableMultiDict(parameters)),
+            parameters=RequestParameters(
+                query=ImmutableMultiDict(parameters), path={}, cookie={}
+            ),
             body=b"",
             mimetype="application/x-www-form-urlencoded",
         )

--- a/tornado_openapi3/requests.py
+++ b/tornado_openapi3/requests.py
@@ -9,7 +9,7 @@ from openapi_core.validation.request.datatypes import (  # type: ignore
 )
 from openapi_core.validation.request import validators  # type: ignore
 from tornado.httpclient import HTTPRequest  # type: ignore
-from tornado.httputil import HTTPServerRequest  # type: ignore
+from tornado.httputil import HTTPServerRequest, parse_cookie  # type: ignore
 from werkzeug.datastructures import ImmutableMultiDict, Headers
 
 from .util import parse_mimetype
@@ -43,7 +43,9 @@ class TornadoRequestFactory:
             full_url_pattern=path,
             method=request.method.lower() if request.method else "get",
             parameters=RequestParameters(
-                query=query_arguments, header=Headers(request.headers.get_all())
+                query=query_arguments,
+                header=Headers(request.headers.get_all()),
+                cookie=parse_cookie(request.headers.get("Cookie", "")),
             ),
             body=request.body if request.body else b"",
             mimetype=parse_mimetype(


### PR DESCRIPTION
Request validation was failing due to a `openapi_core.validation.exceptions.InvalidSecurity` exception being raised, as the request was being made with a session cookie, and cookies were not added to the `RequestParameters` object when it was created.

Path was included on L128, as the test was failing without it.