### PR TITLE
Use None for no request body instead of b""

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -99,7 +99,7 @@ class TestRequestFactory(unittest.TestCase):
             full_url_pattern=url,
             method="get",
             parameters=RequestParameters(query=ImmutableMultiDict(parameters)),
-            body=b"",
+            body=None,
             mimetype="application/x-www-form-urlencoded",
         )
         openapi_request = TornadoRequestFactory.create(tornado_request)
@@ -127,7 +127,7 @@ class TestRequestFactory(unittest.TestCase):
             parameters=RequestParameters(
                 query=ImmutableMultiDict(parameters), path={}, cookie={}
             ),
-            body=b"",
+            body=None,
             mimetype="application/x-www-form-urlencoded",
         )
         openapi_request = TornadoRequestFactory.create(tornado_request)

--- a/tornado_openapi3/requests.py
+++ b/tornado_openapi3/requests.py
@@ -55,7 +55,7 @@ class TornadoRequestFactory:
                 header=Headers(request.headers.get_all()),
                 cookie=parse_cookie(request.headers.get("Cookie", "")),
             ),
-            body=request.body if request.body else b"",
+            body=request.body if request.body else None,
             mimetype=parse_mimetype(
                 request.headers.get("Content-Type", "application/x-www-form-urlencoded")
             ),


### PR DESCRIPTION
This is how openapi-core expects a lack of request body. Currently it can cause issues with validation because requests without a body will be send to the validator with a request a body of empty bytes that can't be validated.